### PR TITLE
Replace Gmail poller with IMAP version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ coverage
 # Nitro build output (ignore everywhere)
 .nitro/
 **/.nitro/
+
+# Mail poller runtime artifacts
+tokens/

--- a/imap-polling-readme.md
+++ b/imap-polling-readme.md
@@ -1,0 +1,83 @@
+# IMAP Poller (Development Only)
+
+This repository includes a lightweight IMAP polling utility that can be used during development to pull new messages from any
+mailbox that exposes an IMAP endpoint (Gmail, Outlook, Fastmail, self-hosted, etc.). The poller signs in with standard IMAP
+credentials, keeps a cursor on disk so each message is processed once, and invokes a stubbed `processMessage()` hook for your
+own downstream processing.
+
+## Features
+
+- Runs locally on `localhost` with no public endpoints, tunnels, or OAuth flows required.
+- Uses [`imapflow`](https://github.com/postalsys/imapflow) to establish an efficient IMAP IDLE-compatible connection.
+- Stores connection state (cursor and a rolling UID cache) under `./tokens/imap-poll-state.json` so messages are not reprocessed
+  between restarts.
+- Polls a configurable mailbox at a configurable interval, logging the sender, subject, and received timestamp for each new
+  message before calling `processMessage()`.
+
+## Prerequisites
+
+1. **Ensure IMAP is enabled for the mailbox you plan to read.**
+   - For hosted providers (Gmail, Outlook.com, Yahoo, Fastmail, etc.) enable IMAP in the account settings if it is not already
+     active.
+   - For Gmail and other providers that no longer support "less secure" passwords, create an App Password and use that instead
+     of your primary account password.
+   - If you host your own mail server, confirm that the IMAP service is reachable from your development machine.
+2. **Collect the connection details.** You will need the hostname, port, TLS requirements, username, and password (or app
+   password) for the IMAP account.
+
+## Local configuration
+
+The poller reads configuration from environment variables. Export them in your shell or place them in an `.env.local` file at
+the repository root (dotenv is loaded automatically).
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `IMAP_HOST` | ✅ | Hostname or IP address of the IMAP server (e.g. `imap.gmail.com`). |
+| `IMAP_PORT` | ✅ | Port for the IMAP server (typically `993` for TLS or `143` for STARTTLS/plain). |
+| `IMAP_SECURE` | Optional | Set to `true` to require an implicit TLS connection (default: `true` when the port is `993`). |
+| `IMAP_USER` | ✅ | Username for the IMAP account. |
+| `IMAP_PASSWORD` | ✅ | Password or app password for the IMAP account. |
+| `IMAP_MAILBOX` | Optional | Mailbox/folder to poll (default: `INBOX`). |
+| `IMAP_REQUIRE_UNSEEN` | Optional | When `true`, only fetches messages that are still marked unseen/unread (default: `false`). |
+| `IMAP_POLL_INTERVAL_SECONDS` | Optional | Seconds between poll cycles (default: `30`). |
+| `IMAP_INITIAL_LOOKBACK_MINUTES` | Optional | How far back to look for messages when the cursor file does not exist (default: `5`). |
+| `IMAP_POLL_MAX_RESULTS` | Optional | Maximum number of messages fetched per poll (default: `25`). |
+| `IMAP_RECENT_MESSAGE_MEMORY` | Optional | Number of recent message UIDs to remember to avoid duplicates (default: `50`). |
+| `IMAP_TLS_REJECT_UNAUTHORIZED` | Optional | Set to `false` to skip TLS certificate validation (not recommended; defaults to `true`). |
+
+> **Security note:** Keep credentials out of source control. The `tokens/` directory is ignored by Git so the cursor and any
+> cached state remain local to your machine.
+
+## Running the poller
+
+1. Install dependencies if you have not already:
+   ```bash
+   npm install
+   ```
+2. Export or configure the environment variables described above.
+3. Start the poller:
+   ```bash
+   npm run imap:poller
+   ```
+4. The script connects to the IMAP server, initializes its cursor (using the configured lookback window on the first run), and
+   then polls continuously. Each new message found is logged and passed to `processMessage()` for custom handling.
+
+### Resetting cursor state
+
+- Delete `tokens/imap-poll-state.json` to reset the polling cursor (the next run will reinitialize using the configured lookback
+  window).
+
+## Extending `processMessage`
+
+The default implementation simply logs that it was invoked. To hook in your own processing logic, edit `scripts/imap-poller.mjs`
+and update the `processMessage` function to call into your application code, enqueue work, or transform the payload as needed.
+
+## Troubleshooting
+
+- **Authentication failures:** Double-check the username/password pair and whether the account requires an app password or
+  additional security steps.
+- **TLS issues:** If you see certificate validation errors when connecting to a development or self-hosted server, temporarily
+  set `IMAP_TLS_REJECT_UNAUTHORIZED=false` while you correct the certificate chain.
+- **No new messages detected:** Ensure you are polling the correct mailbox and, if `IMAP_REQUIRE_UNSEEN=true`, verify that the
+  messages are still marked unread. Deleting `tokens/imap-poll-state.json` forces the poller to rebuild its cursor using the
+  configured lookback window.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,9 @@
         "@aws-sdk/client-s3": "^3.864.0",
         "@aws-sdk/s3-request-presigner": "^3.873.0",
         "@mdi/font": "^7.4.47",
+        "dotenv": "^17.2.2",
         "drizzle-orm": "^0.44.4",
+        "imapflow": "^1.0.164",
         "openai": "^5.12.2",
         "pg": "^8.16.3",
         "pinia": "^3.0.3",
@@ -6924,6 +6926,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/b4a": {
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
@@ -8236,10 +8247,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.2.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
-      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
-      "dev": true,
+      "version": "17.2.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.2.tgz",
+      "integrity": "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -8489,6 +8499,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/encoding-japanese": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/encoding-japanese/-/encoding-japanese-2.2.0.tgz",
+      "integrity": "sha512-EuJWwlHPZ1LbADuKTClvHtwbaFn4rOD+dRAbWysqEOXRc2Uui0hJInNJrsdH0c+OhJA4nrCBdSkW4DD5YxAo6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.10.0"
       }
     },
     "node_modules/end-of-stream": {
@@ -9116,6 +9135,15 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-redact": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
+      "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/fast-xml-parser": {
       "version": "5.2.5",
@@ -9839,7 +9867,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -9877,6 +9904,39 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/imapflow": {
+      "version": "1.0.196",
+      "resolved": "https://registry.npmjs.org/imapflow/-/imapflow-1.0.196.tgz",
+      "integrity": "sha512-KJ1pgT01qFm/7iwvA3dCMER5t5A0zD8OKpW5eEQ73XCrezrn4hO71nEycFIrV0IyqQXMgIhD6qDldgoZcTEjww==",
+      "license": "MIT",
+      "dependencies": {
+        "encoding-japanese": "2.2.0",
+        "iconv-lite": "0.7.0",
+        "libbase64": "1.3.0",
+        "libmime": "5.3.7",
+        "libqp": "2.1.1",
+        "mailsplit": "5.4.6",
+        "nodemailer": "7.0.6",
+        "pino": "9.9.5",
+        "socks": "2.8.7"
+      }
+    },
+    "node_modules/imapflow/node_modules/iconv-lite": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/immutable": {
@@ -9962,6 +10022,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ioredis"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/iron-webcrypto": {
@@ -10595,6 +10664,30 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/libbase64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/libbase64/-/libbase64-1.3.0.tgz",
+      "integrity": "sha512-GgOXd0Eo6phYgh0DJtjQ2tO8dc0IVINtZJeARPeiIJqge+HdsWSuaDTe8ztQ7j/cONByDZ3zeB325AHiv5O0dg==",
+      "license": "MIT"
+    },
+    "node_modules/libmime": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/libmime/-/libmime-5.3.7.tgz",
+      "integrity": "sha512-FlDb3Wtha8P01kTL3P9M+ZDNDWPKPmKHWaU/cG/lg5pfuAwdflVpZE+wm9m7pKmC5ww6s+zTxBKS1p6yl3KpSw==",
+      "license": "MIT",
+      "dependencies": {
+        "encoding-japanese": "2.2.0",
+        "iconv-lite": "0.6.3",
+        "libbase64": "1.3.0",
+        "libqp": "2.1.1"
+      }
+    },
+    "node_modules/libqp": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/libqp/-/libqp-2.1.1.tgz",
+      "integrity": "sha512-0Wd+GPz1O134cP62YU2GTOPNA7Qgl09XwCqM5zpBv87ERCXdfDtyKXvV7c9U22yWJh44QZqBocFnXN11K96qow==",
+      "license": "MIT"
+    },
     "node_modules/listhen": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/listhen/-/listhen-1.9.0.tgz",
@@ -10770,6 +10863,17 @@
         "@babel/parser": "^7.25.4",
         "@babel/types": "^7.25.4",
         "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/mailsplit": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/mailsplit/-/mailsplit-5.4.6.tgz",
+      "integrity": "sha512-M+cqmzaPG/mEiCDmqQUz8L177JZLZmXAUpq38owtpq2xlXlTSw+kntnxRt2xsxVFFV6+T8Mj/U0l5s7s6e0rNw==",
+      "license": "(MIT OR EUPL-1.1+)",
+      "dependencies": {
+        "libbase64": "1.3.0",
+        "libmime": "5.3.7",
+        "libqp": "2.1.1"
       }
     },
     "node_modules/math-intrinsics": {
@@ -11378,6 +11482,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/nodemailer": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.6.tgz",
+      "integrity": "sha512-F44uVzgwo49xboqbFgBGkRaiMgtoBrBEWCVincJPK9+S9Adkzt/wXCLKbf7dxucmxfTI5gHGB+bEmdyzN6QKjw==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/nopt": {
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
@@ -11616,6 +11729,15 @@
       "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -12134,6 +12256,43 @@
         }
       }
     },
+    "node_modules/pino": {
+      "version": "9.9.5",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.9.5.tgz",
+      "integrity": "sha512-d1s98p8/4TfYhsJ09r/Azt30aYELRi6NNnZtEbqFw6BoGsdPVf5lKNK3kUwH8BmJJfpTLNuicjUQjaMbd93dVg==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.1.1",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
+      "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
+      "license": "MIT"
+    },
     "node_modules/pkg-types": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
@@ -12341,6 +12500,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
@@ -12421,6 +12596,12 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
     },
     "node_modules/quote-unquote": {
@@ -12584,6 +12765,15 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/redis-errors": {
@@ -12898,7 +13088,6 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
       "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -12908,7 +13097,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/sass": {
@@ -13200,12 +13388,45 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
     "node_modules/smob": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/smob/-/smob-1.5.0.tgz",
       "integrity": "sha512-g6T+p7QO8npa+/hNx9ohv1E5pVCmWrVCUzUXJyLdMmftX6ER0oiWY/w9knEonLpnOp6b6FenKnMfR8gqwWdwig==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
+      "integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
     },
     "node_modules/source-map": {
       "version": "0.7.6",
@@ -13668,6 +13889,15 @@
       "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/thread-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
+      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "test:unit": "vitest",
     "build-only": "vite build",
     "type-check": "vue-tsc --build",
-    "lint": "eslint . --fix"
+    "lint": "eslint . --fix",
+    "imap:poller": "node scripts/imap-poller.mjs"
   },
   "dependencies": {
     "@awesomeposter/db": "file:./packages/db",
@@ -30,7 +31,9 @@
     "@aws-sdk/client-s3": "^3.864.0",
     "@aws-sdk/s3-request-presigner": "^3.873.0",
     "@mdi/font": "^7.4.47",
+    "dotenv": "^17.2.2",
     "drizzle-orm": "^0.44.4",
+    "imapflow": "^1.0.164",
     "openai": "^5.12.2",
     "pg": "^8.16.3",
     "pinia": "^3.0.3",

--- a/scripts/imap-poller.mjs
+++ b/scripts/imap-poller.mjs
@@ -1,0 +1,446 @@
+#!/usr/bin/env node
+import { ImapFlow } from 'imapflow'
+import { readFile, writeFile, mkdir } from 'node:fs/promises'
+import path from 'node:path'
+import process from 'node:process'
+import { config as loadEnv } from 'dotenv'
+
+loadEnv()
+
+function parseInteger(name, rawValue, defaultValue, minimum) {
+  const hasRaw = typeof rawValue === 'string' && rawValue.trim() !== ''
+  const valueToParse = hasRaw ? rawValue : defaultValue !== null ? String(defaultValue) : null
+
+  if (valueToParse === null) {
+    throw new Error(`${name} environment variable is required`)
+  }
+
+  const parsed = Number.parseInt(valueToParse, 10)
+  if (Number.isNaN(parsed)) {
+    throw new Error(`${name} must be an integer`)
+  }
+
+  if (parsed < minimum) {
+    throw new Error(`${name} must be greater than or equal to ${minimum}`)
+  }
+
+  return parsed
+}
+
+function parseBoolean(name, rawValue, defaultValue) {
+  if (rawValue === undefined || rawValue === null || String(rawValue).trim() === '') {
+    return defaultValue
+  }
+
+  const normalized = String(rawValue).trim().toLowerCase()
+  if (['true', '1', 'yes', 'y', 'on'].includes(normalized)) {
+    return true
+  }
+  if (['false', '0', 'no', 'n', 'off'].includes(normalized)) {
+    return false
+  }
+
+  throw new Error(`${name} must be a boolean-like value (true/false)`) 
+}
+
+function requireString(name, rawValue) {
+  if (!rawValue || rawValue.trim() === '') {
+    throw new Error(`${name} environment variable is required`)
+  }
+  return rawValue.trim()
+}
+
+const pollIntervalSeconds = parseInteger(
+  'IMAP_POLL_INTERVAL_SECONDS',
+  process.env.IMAP_POLL_INTERVAL_SECONDS,
+  30,
+  1,
+)
+
+const initialLookbackMinutes = parseInteger(
+  'IMAP_INITIAL_LOOKBACK_MINUTES',
+  process.env.IMAP_INITIAL_LOOKBACK_MINUTES,
+  5,
+  0,
+)
+
+const maxResults = parseInteger(
+  'IMAP_POLL_MAX_RESULTS',
+  process.env.IMAP_POLL_MAX_RESULTS,
+  25,
+  1,
+)
+
+const recentMessageRetention = parseInteger(
+  'IMAP_RECENT_MESSAGE_MEMORY',
+  process.env.IMAP_RECENT_MESSAGE_MEMORY,
+  50,
+  1,
+)
+
+const host = requireString('IMAP_HOST', process.env.IMAP_HOST)
+const port = parseInteger('IMAP_PORT', process.env.IMAP_PORT, null, 1)
+const user = requireString('IMAP_USER', process.env.IMAP_USER)
+const password = requireString('IMAP_PASSWORD', process.env.IMAP_PASSWORD)
+const mailbox = (process.env.IMAP_MAILBOX ?? 'INBOX').trim() || 'INBOX'
+
+const secure = parseBoolean('IMAP_SECURE', process.env.IMAP_SECURE, port === 993)
+const requireUnseen = parseBoolean('IMAP_REQUIRE_UNSEEN', process.env.IMAP_REQUIRE_UNSEEN, false)
+const rejectUnauthorized = parseBoolean(
+  'IMAP_TLS_REJECT_UNAUTHORIZED',
+  process.env.IMAP_TLS_REJECT_UNAUTHORIZED,
+  true,
+)
+
+const repoRoot = process.cwd()
+const tokensDir = path.resolve(repoRoot, 'tokens')
+const stateFilePath = path.join(tokensDir, 'imap-poll-state.json')
+
+function log(...args) {
+  console.log('[imap-poller]', ...args)
+}
+
+function logError(message, error) {
+  console.error('[imap-poller]', message, error)
+}
+
+async function ensureTokensDir() {
+  await mkdir(tokensDir, { recursive: true })
+}
+
+async function loadJson(filePath, defaultValue) {
+  try {
+    const raw = await readFile(filePath, 'utf8')
+    return JSON.parse(raw)
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      return defaultValue
+    }
+
+    throw error
+  }
+}
+
+async function saveJson(filePath, data) {
+  await ensureTokensDir()
+  await writeFile(filePath, `${JSON.stringify(data, null, 2)}\n`, 'utf8')
+}
+
+function formatAddress(address) {
+  if (!address) {
+    return '(unknown sender)'
+  }
+
+  const name = address.name ? address.name.trim() : ''
+  const email = address.address ? address.address.trim() : ''
+
+  if (name && email) {
+    return `${name} <${email}>`
+  }
+
+  if (email) {
+    return email
+  }
+
+  if (name) {
+    return name
+  }
+
+  return '(unknown sender)'
+}
+
+async function processMessage(message) {
+  log('processMessage stub invoked for UID', message.uid)
+}
+
+class ImapPoller {
+  constructor(options) {
+    this.options = options
+    this.cursor = { lastUid: null, lastInternalDate: null, recentMessageUids: [] }
+    this.intervalHandle = null
+    this.isPolling = false
+    this.mailboxOpened = false
+
+    this.client = new ImapFlow({
+      host: options.host,
+      port: options.port,
+      secure: options.secure,
+      auth: {
+        user: options.user,
+        pass: options.password,
+      },
+      tls: {
+        rejectUnauthorized: options.rejectUnauthorized,
+      },
+    })
+
+    this.client.on('error', (error) => {
+      logError('IMAP client error', error)
+    })
+
+    this.client.on('close', () => {
+      log('IMAP connection closed')
+      this.mailboxOpened = false
+    })
+
+    this.client.on('mailboxClose', () => {
+      this.mailboxOpened = false
+    })
+
+    this.client.on('mailboxOpen', () => {
+      this.mailboxOpened = true
+    })
+  }
+
+  async initialize() {
+    await ensureTokensDir()
+
+    const persistedState = await loadJson(this.options.stateFilePath, null)
+    if (persistedState && typeof persistedState === 'object') {
+      const { lastUid, lastInternalDate, recentMessageUids } = persistedState
+
+      if (typeof lastUid === 'number' && Number.isFinite(lastUid) && lastUid > 0) {
+        this.cursor.lastUid = lastUid
+      }
+
+      if (typeof lastInternalDate === 'number' && Number.isFinite(lastInternalDate) && lastInternalDate >= 0) {
+        this.cursor.lastInternalDate = lastInternalDate
+      }
+
+      if (Array.isArray(recentMessageUids)) {
+        this.cursor.recentMessageUids = recentMessageUids
+          .map((value) => {
+            if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+              return value
+            }
+            return null
+          })
+          .filter((value) => value !== null)
+      }
+    }
+
+    if (typeof this.cursor.lastInternalDate !== 'number') {
+      const initialCursor = Date.now() - this.options.initialLookbackMs
+      this.cursor.lastInternalDate = Math.max(0, initialCursor)
+      log(`Initialized polling cursor to ${new Date(this.cursor.lastInternalDate).toISOString()}`)
+    }
+
+    if (!Array.isArray(this.cursor.recentMessageUids)) {
+      this.cursor.recentMessageUids = []
+    }
+
+    await this.persistCursor()
+    await this.ensureConnected()
+  }
+
+  async ensureConnected() {
+    if (!this.client.usable) {
+      await this.client.connect()
+      log(`Connected to IMAP server ${this.options.host}:${this.options.port}`)
+    }
+
+    if (!this.mailboxOpened || !this.client.mailbox || this.client.mailbox.path !== this.options.mailbox) {
+      await this.client.mailboxOpen(this.options.mailbox, { readOnly: true })
+      log(`Opened mailbox ${this.options.mailbox}`)
+    }
+  }
+
+  async start() {
+    await this.initialize()
+    await this.pollOnce()
+
+    this.intervalHandle = setInterval(() => {
+      this.pollOnce().catch((error) => {
+        logError('Polling cycle failed', error)
+      })
+    }, this.options.pollIntervalMs)
+
+    log(`Polling mailbox ${this.options.mailbox} every ${this.options.pollIntervalMs / 1000} seconds`)
+  }
+
+  stop() {
+    if (this.intervalHandle) {
+      clearInterval(this.intervalHandle)
+      this.intervalHandle = null
+    }
+  }
+
+  async shutdown() {
+    this.stop()
+
+    try {
+      if (this.client.usable) {
+        await this.client.logout()
+      } else {
+        this.client.close()
+      }
+    } catch (error) {
+      logError('Error closing IMAP connection', error)
+    }
+  }
+
+  async pollOnce() {
+    if (this.isPolling) {
+      log('Skipping poll because previous cycle is still running')
+      return
+    }
+
+    this.isPolling = true
+    let lock
+
+    try {
+      await this.ensureConnected()
+      lock = await this.client.getMailboxLock(this.options.mailbox, { readOnly: true })
+
+      const searchCriteria = {}
+
+      if (this.options.requireUnseen) {
+        searchCriteria.seen = false
+      }
+
+      if (typeof this.cursor.lastUid === 'number' && this.cursor.lastUid > 0) {
+        searchCriteria.uid = `${this.cursor.lastUid + 1}:*`
+      } else if (typeof this.cursor.lastInternalDate === 'number' && this.cursor.lastInternalDate > 0) {
+        searchCriteria.since = new Date(this.cursor.lastInternalDate)
+      } else {
+        searchCriteria.all = true
+      }
+
+      const searchResult = await this.client.search(searchCriteria, { uid: true })
+      const uids = Array.isArray(searchResult) ? searchResult : []
+
+      if (uids.length === 0) {
+        log('No new messages detected')
+        return
+      }
+
+      const limitedUids = uids.length > this.options.maxResults ? uids.slice(-this.options.maxResults) : uids
+
+      const messages = []
+      for await (const message of this.client.fetch(limitedUids, {
+        uid: true,
+        envelope: true,
+        internalDate: true,
+        flags: true,
+      })) {
+        const envelope = message.envelope ?? {}
+        const fromAddress = formatAddress(envelope.from && envelope.from.length > 0 ? envelope.from[0] : null)
+        const subject = envelope.subject && envelope.subject.trim() ? envelope.subject : '(no subject)'
+        const internalDate = message.internalDate instanceof Date ? message.internalDate.getTime() : Date.now()
+        const dateCandidate = envelope.date instanceof Date ? envelope.date : message.internalDate ?? new Date(internalDate)
+        const normalizedDate = dateCandidate instanceof Date ? dateCandidate : new Date(internalDate)
+
+        messages.push({
+          uid: message.uid,
+          messageId: envelope.messageId ?? null,
+          from: fromAddress,
+          subject,
+          date: normalizedDate,
+          internalDate,
+          flags: message.flags ? Array.from(message.flags) : [],
+        })
+      }
+
+      if (messages.length === 0) {
+        log('No new messages detected')
+        return
+      }
+
+      messages.sort((a, b) => {
+        if (a.internalDate === b.internalDate) {
+          return a.uid - b.uid
+        }
+        return a.internalDate - b.internalDate
+      })
+
+      const recentUids = new Set(this.cursor.recentMessageUids ?? [])
+
+      for (const message of messages) {
+        if (!Number.isFinite(message.uid)) {
+          continue
+        }
+
+        if (recentUids.has(message.uid)) {
+          continue
+        }
+
+        if (
+          typeof this.cursor.lastInternalDate === 'number' &&
+          this.cursor.lastInternalDate > 0 &&
+          message.internalDate < this.cursor.lastInternalDate
+        ) {
+          continue
+        }
+
+        log(
+          `New message UID ${message.uid} from ${message.from} | Subject: ${message.subject} | Date: ${message.date.toISOString()}`,
+        )
+        await processMessage(message)
+
+        this.cursor.lastUid = typeof this.cursor.lastUid === 'number' && this.cursor.lastUid > 0
+          ? Math.max(this.cursor.lastUid, message.uid)
+          : message.uid
+        this.cursor.lastInternalDate = Math.max(this.cursor.lastInternalDate ?? 0, message.internalDate)
+        this.cursor.recentMessageUids = [...(this.cursor.recentMessageUids ?? []), message.uid]
+        if (this.cursor.recentMessageUids.length > this.options.recentMessageRetention) {
+          this.cursor.recentMessageUids = this.cursor.recentMessageUids.slice(-this.options.recentMessageRetention)
+        }
+        recentUids.add(message.uid)
+        await this.persistCursor()
+      }
+    } catch (error) {
+      logError('Encountered an error while polling IMAP', error)
+      this.mailboxOpened = false
+    } finally {
+      if (lock) {
+        lock.release()
+      }
+      this.isPolling = false
+    }
+  }
+
+  async persistCursor() {
+    await saveJson(this.options.stateFilePath, this.cursor)
+  }
+}
+
+async function main() {
+  const options = {
+    host,
+    port,
+    secure,
+    user,
+    password,
+    mailbox,
+    requireUnseen,
+    rejectUnauthorized,
+    pollIntervalMs: pollIntervalSeconds * 1000,
+    initialLookbackMs: initialLookbackMinutes * 60 * 1000,
+    stateFilePath,
+    maxResults,
+    recentMessageRetention,
+  }
+
+  const poller = new ImapPoller(options)
+  await poller.start()
+
+  const shutdown = () => {
+    log('Shutting down IMAP poller')
+    poller
+      .shutdown()
+      .catch((error) => {
+        logError('Error during IMAP poller shutdown', error)
+      })
+      .finally(() => {
+        process.exit(0)
+      })
+  }
+
+  process.on('SIGINT', shutdown)
+  process.on('SIGTERM', shutdown)
+}
+
+main().catch((error) => {
+  logError('Failed to start IMAP poller', error)
+  process.exitCode = 1
+})


### PR DESCRIPTION
## Summary
- replace the previous Gmail OAuth poller with an IMAP-based implementation that persists its cursor under `tokens/` and logs new messages before invoking `processMessage`
- document IMAP configuration, credentials, and troubleshooting guidance in the new `imap-polling-readme.md`
- update project wiring by adding an `imap:poller` npm script, pulling in the `imapflow` dependency, and keeping poller artifacts ignored by git

## Testing
- npx eslint scripts/imap-poller.mjs

------
https://chatgpt.com/codex/tasks/task_e_68c9b6d2935083248dab4bd18395be50