### PR TITLE
Add shared approval advisory types

### DIFF
--- a/packages/shared/src/agent-run.test.ts
+++ b/packages/shared/src/agent-run.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ApprovalAdvisorySchema,
+  ApprovalDecisionStatusEnum,
+  PendingApprovalSchema,
+} from './agent-run.js'
+
+describe('approval advisory schema', () => {
+  it('serializes and deserializes advisories with optional fields', () => {
+    const advisory = ApprovalAdvisorySchema.parse({
+      severity: 'warn',
+      reason: 'High risk content detected',
+      evidenceRefs: ['asset-123'],
+      suggestedRoles: ['legal', 'compliance'],
+      autoEscalate: true,
+    })
+
+    expect(advisory).toEqual({
+      severity: 'warn',
+      reason: 'High risk content detected',
+      evidenceRefs: ['asset-123'],
+      suggestedRoles: ['legal', 'compliance'],
+      autoEscalate: true,
+    })
+  })
+
+  it('defaults optional arrays when not provided', () => {
+    const advisory = ApprovalAdvisorySchema.parse({
+      severity: 'info',
+      reason: 'Provide additional context',
+    })
+
+    expect(advisory.evidenceRefs).toEqual([])
+    expect(advisory.suggestedRoles).toBeUndefined()
+    expect(advisory.autoEscalate).toBeUndefined()
+  })
+})
+
+describe('pending approval schema', () => {
+  it('parses minimal pending approvals with defaults applied', () => {
+    const approval = PendingApprovalSchema.parse({
+      checkpointId: 'chk-1',
+      reason: 'Manual approval required',
+      requestedBy: 'orchestrator',
+    })
+
+    expect(approval).toMatchObject({
+      checkpointId: 'chk-1',
+      reason: 'Manual approval required',
+      requestedBy: 'orchestrator',
+      requiredRoles: [],
+      evidenceRefs: [],
+      status: 'waiting',
+    })
+  })
+
+  it('parses completed approvals with advisory metadata', () => {
+    const approval = PendingApprovalSchema.parse({
+      checkpointId: 'chk-2',
+      reason: 'Escalated for legal review',
+      requestedBy: 'orchestrator',
+      requestedAt: '2025-01-01T00:00:00.000Z',
+      requiredRoles: ['legal'],
+      evidenceRefs: ['asset-456'],
+      advisory: {
+        severity: 'block',
+        reason: 'Potential regulatory violation',
+        evidenceRefs: ['asset-456'],
+        suggestedRoles: ['legal'],
+        autoEscalate: true,
+      },
+      status: 'approved',
+      decidedBy: 'reviewer-1',
+      decidedAt: '2025-01-01T01:00:00.000Z',
+      decisionNotes: 'Reviewed by counsel',
+    })
+
+    expect(approval.status).toBe(ApprovalDecisionStatusEnum.enum.approved)
+    expect(approval.requiredRoles).toEqual(['legal'])
+    expect(approval.advisory?.severity).toBe('block')
+  })
+})

--- a/packages/shared/src/agent-run.ts
+++ b/packages/shared/src/agent-run.ts
@@ -198,6 +198,45 @@ export const PlanPatchSchema = z.object({
 })
 export type PlanPatch = z.infer<typeof PlanPatchSchema>
 
+
+export const ApprovalSeverityEnum = z.enum(['info', 'warn', 'block'])
+export type ApprovalSeverity = z.infer<typeof ApprovalSeverityEnum>
+
+export const ApprovalReviewerRoleEnum = z.enum([
+  'marketing_manager',
+  'legal',
+  'compliance',
+  'executive'
+])
+export type ApprovalReviewerRole = z.infer<typeof ApprovalReviewerRoleEnum>
+
+export const ApprovalAdvisorySchema = z.object({
+  severity: ApprovalSeverityEnum,
+  reason: z.string().min(1),
+  evidenceRefs: z.array(z.string()).default([]),
+  suggestedRoles: z.array(ApprovalReviewerRoleEnum).optional(),
+  autoEscalate: z.boolean().optional()
+})
+export type ApprovalAdvisory = z.infer<typeof ApprovalAdvisorySchema>
+
+export const ApprovalDecisionStatusEnum = z.enum(['waiting', 'approved', 'rejected'])
+export type ApprovalDecisionStatus = z.infer<typeof ApprovalDecisionStatusEnum>
+
+export const PendingApprovalSchema = z.object({
+  checkpointId: z.string(),
+  reason: z.string().min(1),
+  requestedBy: z.string().min(1),
+  requestedAt: z.string().datetime().optional(),
+  requiredRoles: z.array(ApprovalReviewerRoleEnum).default([]),
+  evidenceRefs: z.array(z.string()).default([]),
+  advisory: ApprovalAdvisorySchema.optional(),
+  status: ApprovalDecisionStatusEnum.default('waiting'),
+  decidedBy: z.string().optional(),
+  decidedAt: z.string().datetime().optional(),
+  decisionNotes: z.string().optional()
+})
+export type PendingApproval = z.infer<typeof PendingApprovalSchema>
+
 // Shared step result schema used by orchestrator and specialists.
 // - stepId: identifier of the plan step this result corresponds to
 // - output: arbitrary structured data produced by the step
@@ -208,6 +247,7 @@ export const StepResultSchema = z.object({
   output: z.any().optional(),
   error: z.string().optional(),
   metrics: z.record(z.any()).optional(),
+  approvalAdvisory: ApprovalAdvisorySchema.optional(),
 })
 export type StepResult = z.infer<typeof StepResultSchema>
 


### PR DESCRIPTION
## Summary
- add shared ApprovalAdvisory and PendingApproval schemas for orchestrator approval checkpoints
- extend StepResult to surface approval advisories from specialists
- add unit coverage for advisory and pending approval serialization contracts

## Testing
- npm run test:unit *(fails: existing agents-server integration tests expecting approval policy behavior)*

------
https://chatgpt.com/codex/tasks/task_e_68cd01e013108324bdabe7cd12cbfd9c