### PR TITLE
feat: add HITL approval UI banner

### DIFF
--- a/src/__tests__/ApprovalCheckpointBanner.spec.ts
+++ b/src/__tests__/ApprovalCheckpointBanner.spec.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import type { PendingApproval } from '@awesomeposter/shared'
+import ApprovalCheckpointBanner from '../components/ApprovalCheckpointBanner.vue'
+import vuetify from '../plugins/vuetify'
+
+describe('ApprovalCheckpointBanner', () => {
+  it('renders approval details and emits actions', async () => {
+    const pending: PendingApproval = {
+      checkpointId: 'cp_123',
+      reason: 'Legal review required',
+      requestedBy: 'orchestrator',
+      requestedAt: '2025-02-16T12:34:56.000Z',
+      requiredRoles: ['legal'],
+      evidenceRefs: ['asset_123'],
+      advisory: {
+        severity: 'warn',
+        reason: 'Claims require legal review',
+        evidenceRefs: ['generation_step'],
+      },
+      status: 'waiting',
+    }
+
+    const wrapper = mount(ApprovalCheckpointBanner, {
+      props: {
+        pending,
+        notes: '',
+        reviewer: '',
+        busy: false,
+        error: null,
+      },
+      global: {
+        plugins: [vuetify],
+      },
+    })
+
+    expect(wrapper.get('[data-testid="approval-banner"]').text()).toContain('Legal review required')
+    expect(wrapper.get('[data-testid="approval-advisory"]').text()).toContain('Claims require legal review')
+    expect(wrapper.get('[data-testid="approval-evidence"]').text()).toContain('asset_123')
+
+    await wrapper.get('[data-testid="approval-reviewer"] input').setValue('Jane Reviewer')
+    await wrapper.get('[data-testid="approval-notes"] textarea').setValue('Looks good to me')
+
+    expect(wrapper.emitted()['update:reviewer']?.[0]).toEqual(['Jane Reviewer'])
+    expect(wrapper.emitted()['update:notes']?.[0]).toEqual(['Looks good to me'])
+
+    await wrapper.get('[data-testid="approval-approve"]').trigger('click')
+    await wrapper.get('[data-testid="approval-reject"]').trigger('click')
+
+    expect(wrapper.emitted().approve).toBeTruthy()
+    expect(wrapper.emitted().reject).toBeTruthy()
+  })
+})

--- a/src/components/ApprovalCheckpointBanner.vue
+++ b/src/components/ApprovalCheckpointBanner.vue
@@ -1,0 +1,159 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { PendingApproval } from '@awesomeposter/shared'
+
+interface Props {
+  pending: PendingApproval
+  busy?: boolean
+  error?: string | null
+  notes: string
+  reviewer: string
+}
+
+const props = defineProps<Props>()
+
+const emit = defineEmits<{
+  (e: 'update:notes', value: string): void
+  (e: 'update:reviewer', value: string): void
+  (e: 'approve'): void
+  (e: 'reject'): void
+}>()
+
+const notesModel = computed({
+  get: () => props.notes,
+  set: (value: string) => emit('update:notes', value),
+})
+
+const reviewerModel = computed({
+  get: () => props.reviewer,
+  set: (value: string) => emit('update:reviewer', value),
+})
+
+const severityColor = computed(() => {
+  const severity = props.pending.advisory?.severity
+  if (severity === 'block') return 'error'
+  if (severity === 'warn') return 'warning'
+  return 'info'
+})
+
+const hasEvidence = computed(() => (props.pending.evidenceRefs?.length ?? 0) > 0)
+const hasRoles = computed(() => (props.pending.requiredRoles?.length ?? 0) > 0)
+
+const formattedRoles = computed(() =>
+  (props.pending.requiredRoles || []).map((role) => {
+    switch (role) {
+      case 'marketing_manager':
+        return 'Marketing'
+      case 'legal':
+        return 'Legal'
+      case 'compliance':
+        return 'Compliance'
+      case 'executive':
+        return 'Executive'
+      default:
+        return role
+    }
+  })
+)
+</script>
+
+<template>
+  <v-alert
+    type="info"
+    variant="tonal"
+    border="start"
+    color="primary"
+    class="approval-banner"
+    data-testid="approval-banner"
+  >
+    <template #title>
+      Awaiting approval &mdash; {{ pending.reason }}
+    </template>
+
+    <div class="text-body-2 mb-2">
+      Requested by <strong>{{ pending.requestedBy }}</strong>
+      <span v-if="pending.requestedAt"> on {{ new Date(pending.requestedAt).toLocaleString() }}</span>
+    </div>
+
+    <v-alert
+      v-if="pending.advisory"
+      :type="severityColor"
+      variant="outlined"
+      border="start"
+      class="mb-3"
+      density="comfortable"
+      data-testid="approval-advisory"
+    >
+      <strong class="text-subtitle-2 d-block mb-1">Advisory</strong>
+      <div class="text-body-2">{{ pending.advisory.reason }}</div>
+    </v-alert>
+
+    <div v-if="hasRoles" class="mb-3">
+      <div class="text-caption text-medium-emphasis mb-1">Required roles</div>
+      <div class="d-flex flex-wrap ga-2">
+        <v-chip v-for="role in formattedRoles" :key="role" size="x-small" color="secondary" variant="flat">
+          {{ role }}
+        </v-chip>
+      </div>
+    </div>
+
+    <div v-if="hasEvidence" class="mb-3">
+      <div class="text-caption text-medium-emphasis mb-1">Evidence</div>
+      <ul class="mb-0 ps-4 text-body-2" data-testid="approval-evidence">
+        <li v-for="ref in pending.evidenceRefs" :key="ref">{{ ref }}</li>
+      </ul>
+    </div>
+
+    <v-text-field
+      v-model="reviewerModel"
+      label="Reviewer name (optional)"
+      density="comfortable"
+      variant="outlined"
+      class="mb-2"
+      :disabled="busy"
+      data-testid="approval-reviewer"
+    />
+
+    <v-textarea
+      v-model="notesModel"
+      label="Decision notes (optional)"
+      auto-grow
+      rows="2"
+      density="comfortable"
+      variant="outlined"
+      class="mb-3"
+      :disabled="busy"
+      data-testid="approval-notes"
+    />
+
+    <div class="d-flex flex-wrap align-center ga-2">
+      <v-btn color="success" @click="emit('approve')" :disabled="busy" data-testid="approval-approve">
+        <v-icon icon="mdi-check" class="me-1" /> Approve
+      </v-btn>
+      <v-btn color="error" variant="outlined" @click="emit('reject')" :disabled="busy" data-testid="approval-reject">
+        <v-icon icon="mdi-close" class="me-1" /> Reject
+      </v-btn>
+      <v-progress-circular indeterminate size="20" class="ms-2" v-if="busy" />
+    </div>
+
+    <v-alert
+      v-if="error"
+      type="error"
+      variant="text"
+      class="mt-3"
+      data-testid="approval-error"
+    >
+      {{ error }}
+    </v-alert>
+  </v-alert>
+</template>
+
+<style scoped>
+.approval-banner {
+  border-left-width: 6px !important;
+}
+
+.ga-2 {
+  gap: 8px;
+}
+</style>

--- a/src/lib/agents-api.ts
+++ b/src/lib/agents-api.ts
@@ -1,0 +1,74 @@
+import type { PendingApproval } from '@awesomeposter/shared'
+
+type ApprovalDecisionInput = {
+  checkpointId: string
+  decision: 'approved' | 'rejected'
+  decidedBy?: string
+  notes?: string
+}
+
+type ApprovalDecisionResponse = {
+  ok: boolean
+  checkpointId: string
+  status: 'approved' | 'rejected'
+}
+
+type PendingApprovalsResponse = {
+  pending?: PendingApproval[]
+}
+
+export const AGENTS_BASE_URL = import.meta.env.VITE_AGENTS_BASE_URL || 'http://localhost:3002'
+export const AGENTS_AUTH = import.meta.env.VITE_AGENTS_AUTH_BEARER || undefined
+
+function buildHeaders(init?: Record<string, string>): Record<string, string> {
+  const headers: Record<string, string> = {
+    Accept: 'application/json',
+    ...init,
+  }
+  if (AGENTS_AUTH) headers['authorization'] = `Bearer ${AGENTS_AUTH}`
+  return headers
+}
+
+export async function listPendingApprovals(threadId: string): Promise<PendingApproval[]> {
+  const url = new URL('/api/v1/orchestrator/approvals', AGENTS_BASE_URL)
+  url.searchParams.set('threadId', threadId)
+
+  const res = await fetch(url.toString(), {
+    method: 'GET',
+    headers: buildHeaders(),
+  })
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    throw new Error(`Failed to load approvals (${res.status}): ${text || res.statusText}`)
+  }
+
+  const json = (await res.json().catch(() => ({}))) as PendingApprovalsResponse
+  if (!json || !Array.isArray(json.pending)) return []
+  return json.pending
+}
+
+export async function postApprovalDecision(input: ApprovalDecisionInput): Promise<ApprovalDecisionResponse> {
+  const res = await fetch(`${AGENTS_BASE_URL}/api/v1/orchestrator/approval`, {
+    method: 'POST',
+    headers: buildHeaders({ 'Content-Type': 'application/json' }),
+    body: JSON.stringify({
+      checkpointId: input.checkpointId,
+      status: input.decision,
+      decidedBy: input.decidedBy,
+      decisionNotes: input.notes,
+    }),
+  })
+
+  const json = (await res.json().catch(() => ({}))) as ApprovalDecisionResponse | { statusMessage?: string; error?: string }
+
+  if (!res.ok || !json || (json as ApprovalDecisionResponse).ok !== true) {
+    const message =
+      (json as { statusMessage?: string }).statusMessage ||
+      (json as { error?: string }).error ||
+      `Approval request failed (${res.status})`
+    throw new Error(message)
+  }
+
+  return json as ApprovalDecisionResponse
+}


### PR DESCRIPTION
## Summary
- add agents API helper functions for orchestrator approvals
- surface pending approval banners and history in the sandbox view
- show approval trail in AgentResultsPopup and introduce reusable approval checkpoint banner with tests

## Testing
- `npx vitest run src/__tests__/ApprovalCheckpointBanner.spec.ts`
- `npm run test:unit` *(fails: requires local @awesomeposter/db/@awesomeposter/shared build artifacts)*
- `npm run lint` *(fails on generated server output and shims outside scope of this change)*

------
https://chatgpt.com/codex/tasks/task_e_68ce6e4a11c08324b653a743116402eb